### PR TITLE
Fix the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,11 @@ var modify = require('gulp-modify');
 
 gulp.task('default', function () {
 	gulp.src('src/app.ext')
-		.pipe(modify(function(content) {
-      return 'modified'
-    }))
+		.pipe(modify({
+			fileModifier: function(file, contents) {
+      				return 'modified';
+    			}
+		}))
 		.pipe(gulp.dest('dist'));
 });
 ```


### PR DESCRIPTION
According to the [source code](https://github.com/efacilitation/gulp-modify/blob/master/index.coffee#L13), we should pass a `fileModifier` within the options, instead of passing the function directly.
